### PR TITLE
Update package.json with repo field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "bin": {
     "colony-compiler": "./bin/colony-compiler.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tessel/colony-compiler.git"
+  },
   "scripts": {
     "test": "./test/npm.js",
     "install": "node shyp-blacklist.js darwin-x64 win32-ia32 win32-x64 || node-gyp rebuild"


### PR DESCRIPTION
Howdy. 

Just noticed that this module does not have a repository field, which upon installtion shows one of these:

```
npm WARN package.json colony-compiler@0.6.12 No repository field.
```

If there is a specific reason why this is not included, then nevermind this. If not, please see attached PR :)

... and now back to playing with my brand new tessel!
