### PR TITLE
Output string literals with CESU-8 sequences

### DIFF
--- a/bin/colony-compiler.js
+++ b/bin/colony-compiler.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env NODE_INVALID_UTF8= node
+#!/usr/bin/env node
 // Copyright 2014 Technical Machine, Inc. See the COPYRIGHT
 // file at the top-level directory of this distribution.
 //


### PR DESCRIPTION
This changes colony's internal string encoding from UTF-8 to [CESU-8](http://en.wikipedia.org/wiki/UTF-8#CESU-8).

Will need a coordinated release with https://github.com/tessel/runtime/pull/542.
